### PR TITLE
Dispose HttpClient in PingOnceAsync

### DIFF
--- a/UrlSupervisor/Monitor.cs
+++ b/UrlSupervisor/Monitor.cs
@@ -74,7 +74,8 @@ namespace UrlSupervisor
 
         public async Task PingOnceAsync()
         {
-            await DoCheckAsync(new HttpClient { Timeout = TimeSpan.FromSeconds(TimeoutSeconds) }, default);
+            using var http = new HttpClient() { Timeout = TimeSpan.FromSeconds(TimeoutSeconds) };
+            await DoCheckAsync(http, default);
         }
 
         public void UpdateFromEditable(EditableMonitor e)


### PR DESCRIPTION
## Summary
- wrap HttpClient in PingOnceAsync with a using statement to ensure disposal

## Testing
- ⚠️ `dotnet build` (command not found)
- ⚠️ `apt-get update` (403 repository not signed)


------
https://chatgpt.com/codex/tasks/task_e_68a74e8b51c88333a9ba5834ed32b4fa