### PR TITLE
Dispose cancellation token source in Monitor

### DIFF
--- a/UrlSupervisor/Monitor.cs
+++ b/UrlSupervisor/Monitor.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace UrlSupervisor
 {
-    public class Monitor : INotifyPropertyChanged
+    public class Monitor : INotifyPropertyChanged, IDisposable
     {
         public string Name { get; private set; }
         public string Url { get; private set; }
@@ -69,7 +69,14 @@ namespace UrlSupervisor
         {
             if (!IsRunning) return;
             _cts?.Cancel();
+            _cts?.Dispose();
             IsRunning = false;
+        }
+
+        public void Dispose()
+        {
+            Stop();
+            _cts?.Dispose();
         }
 
         public async Task PingOnceAsync()


### PR DESCRIPTION
## Summary
- dispose cancellation token source when stopping monitors
- implement IDisposable on Monitor to ensure resource cleanup

## Testing
- `dotnet test UrlSupervisor.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a754b2966883338d22c9681d92a5cf