### PR TITLE
Refactor brush converters into single parameterized implementation

### DIFF
--- a/UrlSupervisor/Converters.cs
+++ b/UrlSupervisor/Converters.cs
@@ -6,27 +6,38 @@ using System.Windows.Media;
 
 namespace UrlSupervisor
 {
-    public class BooleanToBrushConverter : IValueConverter
+    public class BoolToBrushConverter : IValueConverter
     {
-        private static readonly SolidColorBrush Green = new SolidColorBrush(System.Windows.Media.Color.FromRgb(0x30, 0xD4, 0xC1));
-        private static readonly SolidColorBrush Red   = new SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0x5A, 0x5A));
+        private static readonly SolidColorBrush Green;
+        private static readonly SolidColorBrush Red;
+
+        static BoolToBrushConverter()
+        {
+            Green = new SolidColorBrush(Color.FromRgb(0x30, 0xD4, 0xC1));
+            Green.Freeze();
+            Red = new SolidColorBrush(Color.FromRgb(0xFF, 0x5A, 0x5A));
+            Red.Freeze();
+        }
+
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             bool b = value is bool v && v;
+            bool invert = false;
+            if (parameter is bool pb)
+            {
+                invert = pb;
+            }
+            else if (parameter is string ps && bool.TryParse(ps, out var parsed))
+            {
+                invert = parsed;
+            }
+            if (invert)
+            {
+                b = !b;
+            }
             return b ? Green : Red;
         }
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
-    }
 
-    public class InvertedBoolToBrushConverter : IValueConverter
-    {
-        private static readonly SolidColorBrush Green = new SolidColorBrush(System.Windows.Media.Color.FromRgb(0x30, 0xD4, 0xC1));
-        private static readonly SolidColorBrush Red   = new SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0x5A, 0x5A));
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            bool b = value is bool v && v;
-            return b ? Red : Green;
-        }
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
     }
 

--- a/UrlSupervisor/MainWindow.xaml
+++ b/UrlSupervisor/MainWindow.xaml
@@ -7,8 +7,7 @@
         mc:Ignorable="d"
         Title="URL Supervisor" Height="900" Width="1500" Background="{StaticResource BrushPetrol}">
     <Window.Resources>
-        <local:BooleanToBrushConverter x:Key="BoolToBrush" />
-        <local:InvertedBoolToBrushConverter x:Key="InvertedBoolToBrush" />
+        <local:BoolToBrushConverter x:Key="BoolToBrush" />
         <local:BoolToVisibilityConverter x:Key="BoolToVisibility" />
         <local:RunningToGlyphConverter x:Key="RunningGlyph" />
 
@@ -85,7 +84,7 @@
 
                                 <DockPanel>
                                     <Ellipse Width="10" Height="10" Margin="0,2,8,0"
-                                             Fill="{Binding HasError, Mode=OneWay, Converter={StaticResource InvertedBoolToBrush}}"/>
+                                             Fill="{Binding HasError, Mode=OneWay, Converter={StaticResource BoolToBrush}, ConverterParameter=true}"/>
                                     <TextBlock DockPanel.Dock="Left" Text="{Binding Name, Mode=OneWay}" FontSize="{DynamicResource TitleFontSize}" FontWeight="Bold"/>
                                     <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
                                         <Button Content="" Style="{StaticResource IconButton}" ToolTip="Ping maintenant" Click="PingNow_Click"/>


### PR DESCRIPTION
## Summary
- consolidate Boolean and inverted brush converters into one BoolToBrushConverter
- share and freeze SolidColorBrush instances for performance
- update XAML to use new converter with inversion parameter

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a755ad9e9c8333a5eb930565c1f397