### PR TITLE
Refactor boolean brush converter

### DIFF
--- a/UrlSupervisor/Converters.cs
+++ b/UrlSupervisor/Converters.cs
@@ -6,27 +6,41 @@ using System.Windows.Media;
 
 namespace UrlSupervisor
 {
-    public class BooleanToBrushConverter : IValueConverter
+    public class BoolToBrushConverter : IValueConverter
     {
-        private static readonly SolidColorBrush Green = new SolidColorBrush(System.Windows.Media.Color.FromRgb(0x30, 0xD4, 0xC1));
-        private static readonly SolidColorBrush Red   = new SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0x5A, 0x5A));
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            bool b = value is bool v && v;
-            return b ? Green : Red;
-        }
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
-    }
+        private static readonly SolidColorBrush GreenBrush;
+        private static readonly SolidColorBrush RedBrush;
 
-    public class InvertedBoolToBrushConverter : IValueConverter
-    {
-        private static readonly SolidColorBrush Green = new SolidColorBrush(System.Windows.Media.Color.FromRgb(0x30, 0xD4, 0xC1));
-        private static readonly SolidColorBrush Red   = new SolidColorBrush(System.Windows.Media.Color.FromRgb(0xFF, 0x5A, 0x5A));
+        static BoolToBrushConverter()
+        {
+            GreenBrush = new SolidColorBrush(Color.FromRgb(0x30, 0xD4, 0xC1));
+            GreenBrush.Freeze();
+            RedBrush = new SolidColorBrush(Color.FromRgb(0xFF, 0x5A, 0x5A));
+            RedBrush.Freeze();
+        }
+
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            bool b = value is bool v && v;
-            return b ? Red : Green;
+            bool result = value is bool b && b;
+
+            bool invert = false;
+            if (parameter is bool boolParam)
+            {
+                invert = boolParam;
+            }
+            else if (parameter is string strParam && bool.TryParse(strParam, out var parsed))
+            {
+                invert = parsed;
+            }
+
+            if (invert)
+            {
+                result = !result;
+            }
+
+            return result ? GreenBrush : RedBrush;
         }
+
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
     }
 

--- a/UrlSupervisor/MainWindow.xaml
+++ b/UrlSupervisor/MainWindow.xaml
@@ -7,8 +7,7 @@
         mc:Ignorable="d"
         Title="URL Supervisor" Height="900" Width="1500" Background="{StaticResource BrushPetrol}">
     <Window.Resources>
-        <local:BooleanToBrushConverter x:Key="BoolToBrush" />
-        <local:InvertedBoolToBrushConverter x:Key="InvertedBoolToBrush" />
+        <local:BoolToBrushConverter x:Key="BoolToBrush" />
         <local:BoolToVisibilityConverter x:Key="BoolToVisibility" />
         <local:RunningToGlyphConverter x:Key="RunningGlyph" />
 
@@ -85,7 +84,7 @@
 
                                 <DockPanel>
                                     <Ellipse Width="10" Height="10" Margin="0,2,8,0"
-                                             Fill="{Binding HasError, Mode=OneWay, Converter={StaticResource InvertedBoolToBrush}}"/>
+                                             Fill="{Binding HasError, Mode=OneWay, Converter={StaticResource BoolToBrush}, ConverterParameter=True}"/>
                                     <TextBlock DockPanel.Dock="Left" Text="{Binding Name, Mode=OneWay}" FontSize="{DynamicResource TitleFontSize}" FontWeight="Bold"/>
                                     <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
                                         <Button Content="" Style="{StaticResource IconButton}" ToolTip="Ping maintenant" Click="PingNow_Click"/>


### PR DESCRIPTION
## Summary
- replace duplicated Boolean converters with a single `BoolToBrushConverter` supporting inversion via `ConverterParameter`
- share and freeze brush instances for improved performance
- update XAML resources and bindings to use the new converter

## Testing
- ⚠️ `dotnet build` (command not found)
- ⚠️ `apt-get update` (403 errors while attempting to install .NET SDK)


------
https://chatgpt.com/codex/tasks/task_e_68a7571d2bb88333ac4fba3e6c23ae49