### PR TITLE
Adjust tooltip and combo colors for readability

### DIFF
--- a/UrlSupervisor/Themes/Styles.xaml
+++ b/UrlSupervisor/Themes/Styles.xaml
@@ -72,6 +72,20 @@
         </Setter>
     </Style>
 
+    <Style TargetType="ToolTip">
+        <Setter Property="Foreground" Value="{DynamicResource BrushInk}"/>
+        <Setter Property="Background" Value="{DynamicResource BrushTileBg}"/>
+    </Style>
+
+    <Style TargetType="ComboBox">
+        <Setter Property="Foreground" Value="{DynamicResource BrushInk}"/>
+        <Setter Property="Background" Value="{DynamicResource BrushTileBg}"/>
+    </Style>
+
+    <Style TargetType="ComboBoxItem">
+        <Setter Property="Foreground" Value="{DynamicResource BrushInk}"/>
+    </Style>
+
     <Style TargetType="TextBox">
         <Setter Property="Background" Value="{DynamicResource BrushTileBg}"/>
         <Setter Property="Foreground" Value="{DynamicResource BrushInk}"/>


### PR DESCRIPTION
## Summary
- apply the application ink brush to tooltip and combo box text so it matches the page theme
- ensure tooltips use the themed background color for better contrast

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6901d70f9b3c83338426179f36608fd5